### PR TITLE
Uses secure graph fetch URL.

### DIFF
--- a/lib/chartd/chart.rb
+++ b/lib/chartd/chart.rb
@@ -2,7 +2,7 @@ require 'chartd/encoder'
 require 'uri'
 
 class Chartd
-  BASE_URL = URI.parse('http://chartd.co/a.png')
+  BASE_URL = URI.parse('https://www.chartd.co/a.png')
 
   class Chart
     ERR_BAD_DATASET = 'Dataset has to be an array of Fixnums and/or Floats.'.freeze


### PR DESCRIPTION
It looks like chartd's SSL certificate is misconfigured. Their certificate covers "*.chartd.co", but their server accepts requests to "chartd.co", which is not covered by their SSL certificate. So, "www.chartd.co" is secure, but "chartd.co" is not.